### PR TITLE
don't log BrokenUserMap error when message is a bot_message.

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -567,14 +567,16 @@ func (bot *Bot) handleRTMEvent(event *slack.RTMEvent) {
 		// We do some heavy logging here because this is troublesome
 		// to find when it breaks and Slack breaks it by deprecating API's
 
+		// Find FromUser by ID if possible, or log error if it's not a bot message
 		user, ok := bot.Users[userID]
 		if ok {
 			log.Debug("User map is ok.")
 			msg.FromUser = &user
-		} else {
+		} else if ev.Msg.SubType != "bot_message" {
 			log.WithFields(log.Fields{
 				"Type":  "BrokenUserMap",
 				"Users": len(bot.Users),
+				"User":  userID,
 			}).Error("User map is broken.")
 		}
 


### PR DESCRIPTION
## Description
bot messages don't have their `User` set in the message payload so they were triggering the `BrokerUserMap` error.

https://api.slack.com/events/message/bot_message
> A bot_message is sent when a message is sent to a channel by an integration "bot". It is like a normal user message, except **it has no associated user**.

## Issues
Not sure if https://github.com/gopherworks/bawt/issues/8 was purely this or something else, but looks like it fixes it (for me at least)

## How Has This Been Tested?
before
```
time="2019-05-23T07:33:25Z" level=debug msg="Message received." Message="&{{message CXXXXXXXX   Ruben de Vries pushed to branch XXX 1558596805.002100  false [] [{334455 XXX   [] [] []   }] <nil>  false 0 bot_message false  1558596805.002100 BXXXXX gitlab <nil>      [] 0 []  [] false <nil>  0 TXXXXXX []  false false} <nil>}"
time="2019-05-23T07:33:25Z" level=error msg="User map is broken." Type=BrokenUserMap Users=25 userID=
time="2019-05-23T07:33:25Z" level=debug msg="Channel map is ok."
```

after
```
time="2019-05-23T08:14:45Z" level=debug msg="Message received." Message="&{{message CXXXXXXXX  Ruben de Vries pushed to branch XXX 1558599285.002500  false [] [{334455 XXX   [] [] []   }] <nil>  false 0 bot_message false  1558599285.002500 BXXXXX gitlab <nil>      [] 0 []  [] false <nil>  0 TXXXXXX []  false false} <nil>}"
time="2019-05-23T08:14:45Z" level=debug msg="Channel map is ok."
```

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change **does not** require a change to the documentation.
- [x] I have updated the documentation accordingly.
